### PR TITLE
Fixing build with latest OSX and Xcode 7.

### DIFF
--- a/make/bsd/makefiles/gcc.make
+++ b/make/bsd/makefiles/gcc.make
@@ -327,11 +327,6 @@ endif
 
 # Flags for generating make dependency flags.
 DEPFLAGS = -MMD -MP -MF $(DEP_DIR)/$(@:%=%.d)
-ifeq ($(USE_CLANG),)
-  ifneq ($(CC_VER_MAJOR), 2)
-    DEPFLAGS += -fpch-deps
-  endif
-endif
 
 # -DDONT_USE_PRECOMPILED_HEADER will exclude all includes in precompiled.hpp.
 ifeq ($(USE_PRECOMPILED_HEADER),0)


### PR DESCRIPTION
Complementary pull request for: https://github.com/JetBrains/jdk8u/pull/1

Unfortunately the build system of `jdk9` went too far ahead, I doubt that backporting it to `jdk8u` is viable. This pull request makes it possible to build the project on current version of OSX (10.11.5) and Xcode (7.3.1), only using single additional make varialbe:
`make COMPILER_WARNINGS_FATAL=false images`
